### PR TITLE
Version 1.1

### DIFF
--- a/include/codes.hxx
+++ b/include/codes.hxx
@@ -743,6 +743,19 @@ namespace Utils {
 
         return radians;
     }
+
+	static u32 rng = 0;
+	static void srand() {
+
+		rng = OSGetTick();
+        OSReport("\nRng -> 0x%x\n", rng);
+
+	}
+
+	static u32 rand() {
+
+		return rng;
+	}
 }
 
 #define LERP(a, b, t) ((a) + (t) * ((b) - (a)))

--- a/include/codes.hxx
+++ b/include/codes.hxx
@@ -465,7 +465,7 @@ public:
                 break;
 
             case TINY_MARIO:
-                if (isCodeActive(GIANT_MARIO) || isCodeActive(WIDE_MARIO))
+                if (isCodeActive(GIANT_MARIO) || isCodeActive(WIDE_MARIO) || isCodeActive(INVERT_MARIO))
                     return true;
                 break;
 
@@ -513,6 +513,18 @@ public:
                 if (isCodeActive(SELFIE_STICK))
                     return true;
                 break;
+            case INVERT_MARIO:
+				if (isCodeActive(TINY_MARIO))
+					return true;
+				break;
+            case OUT_OF_BODY:
+                if (isCodeActive(MAKE_MARIO_OBJ))
+                    return true;
+                break;
+            case MAKE_MARIO_OBJ:
+                if (isCodeActive(OUT_OF_BODY))
+                    return true;
+                break;
         }
 
 		return false;
@@ -548,6 +560,11 @@ public:
 		}
 
 		return true;
+	}
+
+	void forceActivateCode(int codeID) {
+        codeList[codeID].isActive   = true;
+        codeList[codeID].timeCalled = currentTime;
 	}
 
 private:

--- a/include/codes.hxx
+++ b/include/codes.hxx
@@ -527,6 +527,10 @@ public:
                 if (isCodeActive(PAUSE_TIMERS))
                     return true;
                 break;
+            case SUN_DRIP:
+				if (isCodeActive(NO_MARIO_REDRAW))
+					return true;
+				break;
         }
 
 		return false;

--- a/include/codes.hxx
+++ b/include/codes.hxx
@@ -409,8 +409,6 @@ public:
                     return true;
                 if (isCodeActive(CRAZY_GRAVITY) && Utils::rand() % 10 != 0)
                     return true;
-                //if (isCodeActive(MOVE_OR_DIE))
-                  //  return true;
                 break;
 
             case POPUP_SAVE_PROMPT:
@@ -450,7 +448,7 @@ public:
 
             case MOVE_OR_DIE:
                 if ((isCodeActive(TANK_CONTROLS) && Utils::rand() % 10 != 0) || isCodeActive(CHAOS_CODE) ||
-                    isCodeActive(SCRAMBLE_TEXTURES) || isCodeActive(WINDY_DAY) || isCodeActive(HELPFUL_INPUT_DISPLAY) || isCodeActive(SIMON_SAYS) || isCodeActive(SNAKE) || isCodeActive(SMS_WIKI) /*|| isCodeActive(FIRE_MOVEMENT)*/)
+                    isCodeActive(SCRAMBLE_TEXTURES) || isCodeActive(WINDY_DAY) || isCodeActive(HELPFUL_INPUT_DISPLAY) || isCodeActive(SIMON_SAYS) || isCodeActive(SNAKE) || isCodeActive(SMS_WIKI))
                     return true;
                 break;
 
@@ -480,7 +478,7 @@ public:
                 break;
 
 			case PAUSE_TIMERS:
-                if (isCodeActive(CHAOS_CODE) || isCodeActive(FAKE_DEATH) || isCodeActive(IMA_TIRED))
+                if (isCodeActive(CHAOS_CODE) || isCodeActive(FAKE_DEATH) || isCodeActive(IMA_TIRED) || isCodeActive(DOUBLE_TIME))
                     return true;
                 break;
 
@@ -523,6 +521,10 @@ public:
                 break;
             case MAKE_MARIO_OBJ:
                 if (isCodeActive(OUT_OF_BODY))
+                    return true;
+                break;
+            case DOUBLE_TIME:
+                if (isCodeActive(PAUSE_TIMERS))
                     return true;
                 break;
         }

--- a/include/codes.hxx
+++ b/include/codes.hxx
@@ -180,6 +180,26 @@ extern float currentTime;  // unit = seconds
 
 #define NO_WHITELIST		   255		// used to stay in DEV_MODE w/o a whitelist
 
+namespace Utils {
+
+	static u32 rng = 0;
+    static void srand() {
+        rng = OSGetTick();
+        OSReport("\nRNG Seed -> %d\n", rng);
+    }
+
+    // more or less a copy of sunshine's rand
+    static u32 rand() {
+        rng = rng * 0x41c64e6d + 0x3039;
+        return rng >> 0x10 & 0x7fff;
+    }
+
+	static void setSeed(u32 seed) {
+		rng = seed;
+        OSReport("\nNew RNG Seed -> %d\n", rng);
+	}
+}
+
 class Code  // we might want to add a member for display name
 {    
 
@@ -338,7 +358,7 @@ public:
             case SCRAMBLE_TEXTURES:
                 if (isCodeActive(SIMON_SAYS) || isCodeActive(SNAKE) || isCodeActive(MOVE_OR_DIE))
                     return true;
-                if (isCodeActive(CHAOS_CODE) && rand() % 100 != 0)
+                if (isCodeActive(CHAOS_CODE) && Utils::rand() % 100 != 0)
                     return true;
                 break;
 
@@ -360,7 +380,7 @@ public:
             case CRAZY_GRAVITY:
                 if (isCodeActive(MOON_GRAVITY))
                     return true;
-                if (isCodeActive(FIRE_MOVEMENT) && rand() % 10 != 0)
+                if (isCodeActive(FIRE_MOVEMENT) && Utils::rand() % 10 != 0)
                     return true;
                 break;
 
@@ -380,14 +400,14 @@ public:
                 break;
 
             case ASCEND:
-                if (isCodeActive(FIRE_MOVEMENT) && rand() % 10 != 0)
+                if (isCodeActive(FIRE_MOVEMENT) && Utils::rand() % 10 != 0)
                     return true;
                 break;
 
             case FIRE_MOVEMENT:
-                if (isCodeActive(ASCEND) && rand() % 10 != 0)
+                if (isCodeActive(ASCEND) && Utils::rand() % 10 != 0)
                     return true;
-                if (isCodeActive(CRAZY_GRAVITY) && rand() % 10 != 0)
+                if (isCodeActive(CRAZY_GRAVITY) && Utils::rand() % 10 != 0)
                     return true;
                 break;
 
@@ -422,12 +442,12 @@ public:
                 break;
 
             case TANK_CONTROLS:
-                if (isCodeActive(MOVE_OR_DIE) && rand() % 10 != 0)
+                if (isCodeActive(MOVE_OR_DIE) && Utils::rand() % 10 != 0)
                     return true;
                 break;
 
             case MOVE_OR_DIE:
-                if ((isCodeActive(TANK_CONTROLS) && rand() % 10 != 0) || isCodeActive(CHAOS_CODE) ||
+                if ((isCodeActive(TANK_CONTROLS) && Utils::rand() % 10 != 0) || isCodeActive(CHAOS_CODE) ||
                     isCodeActive(SCRAMBLE_TEXTURES) || isCodeActive(WINDY_DAY) || isCodeActive(HELPFUL_INPUT_DISPLAY) || isCodeActive(SIMON_SAYS) || isCodeActive(SNAKE) || isCodeActive(SMS_WIKI))
                     return true;
                 break;
@@ -528,7 +548,7 @@ public:
 	}
 
 private:
-	int getRand() { return (rand() % currentCodeCount); }
+    int getRand() { return (Utils::rand() % currentCodeCount); }
 
 	int getWeightedRand() {
         int roll;
@@ -538,10 +558,10 @@ private:
             roll = getRand();
 
             if (isCodeActive(REVERSE_RARITIES)) {
-                if (codeList[roll].rarity < rand() % 101)
+                if (codeList[roll].rarity < Utils::rand() % 101)
                     return roll;
             } else {
-                if (codeList[roll].rarity > rand() % 101)
+                if (codeList[roll].rarity > Utils::rand() % 101)
                     return roll;
             }
             
@@ -742,20 +762,7 @@ namespace Utils {
             radians += 2 * M_PI;
 
         return radians;
-    }
-
-	static u32 rng = 0;
-	static void srand() {
-
-		rng = OSGetTick();
-        OSReport("\nRng -> 0x%x\n", rng);
-
-	}
-
-	static u32 rand() {
-
-		return rng;
-	}
+    }	
 }
 
 #define LERP(a, b, t) ((a) + (t) * ((b) - (a)))

--- a/include/codes.hxx
+++ b/include/codes.hxx
@@ -409,6 +409,8 @@ public:
                     return true;
                 if (isCodeActive(CRAZY_GRAVITY) && Utils::rand() % 10 != 0)
                     return true;
+                if (isCodeActive(MOVE_OR_DIE))
+                    return true;
                 break;
 
             case POPUP_SAVE_PROMPT:
@@ -448,7 +450,7 @@ public:
 
             case MOVE_OR_DIE:
                 if ((isCodeActive(TANK_CONTROLS) && Utils::rand() % 10 != 0) || isCodeActive(CHAOS_CODE) ||
-                    isCodeActive(SCRAMBLE_TEXTURES) || isCodeActive(WINDY_DAY) || isCodeActive(HELPFUL_INPUT_DISPLAY) || isCodeActive(SIMON_SAYS) || isCodeActive(SNAKE) || isCodeActive(SMS_WIKI))
+                    isCodeActive(SCRAMBLE_TEXTURES) || isCodeActive(WINDY_DAY) || isCodeActive(HELPFUL_INPUT_DISPLAY) || isCodeActive(SIMON_SAYS) || isCodeActive(SNAKE) || isCodeActive(SMS_WIKI) || isCodeActive(FIRE_MOVEMENT))
                     return true;
                 break;
 
@@ -541,6 +543,7 @@ public:
             case LOL:
             case MOVE_OR_DIE:
 			case DIVING_MODE:
+            case DUMMY_THICC_MARIO:
                 return false;
 		}
 

--- a/include/codes.hxx
+++ b/include/codes.hxx
@@ -409,8 +409,8 @@ public:
                     return true;
                 if (isCodeActive(CRAZY_GRAVITY) && Utils::rand() % 10 != 0)
                     return true;
-                if (isCodeActive(MOVE_OR_DIE))
-                    return true;
+                //if (isCodeActive(MOVE_OR_DIE))
+                  //  return true;
                 break;
 
             case POPUP_SAVE_PROMPT:
@@ -450,7 +450,7 @@ public:
 
             case MOVE_OR_DIE:
                 if ((isCodeActive(TANK_CONTROLS) && Utils::rand() % 10 != 0) || isCodeActive(CHAOS_CODE) ||
-                    isCodeActive(SCRAMBLE_TEXTURES) || isCodeActive(WINDY_DAY) || isCodeActive(HELPFUL_INPUT_DISPLAY) || isCodeActive(SIMON_SAYS) || isCodeActive(SNAKE) || isCodeActive(SMS_WIKI) || isCodeActive(FIRE_MOVEMENT))
+                    isCodeActive(SCRAMBLE_TEXTURES) || isCodeActive(WINDY_DAY) || isCodeActive(HELPFUL_INPUT_DISPLAY) || isCodeActive(SIMON_SAYS) || isCodeActive(SNAKE) || isCodeActive(SMS_WIKI) /*|| isCodeActive(FIRE_MOVEMENT)*/)
                     return true;
                 break;
 
@@ -597,6 +597,7 @@ public:
     static void holdCap();
     static void noMActorModels(Code::FuncReset);
     static void stopTLiveActorPerform(Code::FuncReset);
+    static void disableStopTLiveActorPerform();	// disables the above code if mario dies
     static void stopControlInputs(Code::FuncReset);
     static void spamSprayCentral(Code::FuncReset);
     static void rollExtraCode(Code::FuncReset);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -765,56 +765,6 @@ BETTER_SMS_FOR_CALLBACK static void setSeedCallback(TApplication *tapp) {
 
 	sCustomRNGSeedSetting.setValueRange({-0x7fffffff, 0x7fffffff, step});
 
-	return;
-
-
-	enum scrollStates {
-        NOT_SCROLLING        = 0,
-        SCROLLING			 = 1,
-        DECIMAL_PLACE_LOCKED = 2
-    };
-
-    static int stickHoldStarted = 0;		// the value of sCustomRNGSeed when it began to get changed
-    //static int step				= 1;		// settings step amount/decimal place being stepped
-    static bool holdingStick    = false;	// if holding stick > 0.3 on x axis
-    static scrollStates scrollState = NOT_SCROLLING;
-    f32 menuTime;
-	
-	f32 absoluteStickValue = tapp->mGamePads[0]->mControlStick.mStickX;  // absolute value of mStickX
-    if (absoluteStickValue < 0)
-        absoluteStickValue *= -1;
-
-	if (absoluteStickValue > 0.2)
-        scrollState = SCROLLING;
-    else
-		scrollState = NOT_SCROLLING;
-
-	if (tapp->mGamePads[0]->mButtons.mInput & JUTGamePad::EButtons::Z)	// overrides the other two scrollStates by design
-        scrollState = DECIMAL_PLACE_LOCKED;
-
-
-	switch (scrollState) {
-
-        case NOT_SCROLLING:			// reset the step counter
-			step = 1;		
-			break;
-
-        case SCROLLING:				// every 5 steps, increase the decimal place that is being stepped
-			if (stickHoldStarted <= sCustomRNGSeed - (5 * step) || stickHoldStarted >= sCustomRNGSeed + (5 * step)) {
-                step             = step * 10;
-                stickHoldStarted = sCustomRNGSeed;
-            }
-            break;
-
-		case DECIMAL_PLACE_LOCKED:	// if z is held, lock the decimal place that is being stepped, even if the control stick is let go
-            stickHoldStarted = sCustomRNGSeed;
-	}
-
-	if (step > 1000000000)	// lock step to 10 decimal places
-        step = 1000000000;
-
-	sCustomRNGSeedSetting.setValueRange({-0x7fffffff, 0x7fffffff, step});
-
 }
 
 static void assignOnDeathDestination(JDrama::TFlagT<u16> nextStageFlag, u16 flags) {
@@ -831,13 +781,16 @@ BETTER_SMS_FOR_CALLBACK static void customSeeds(TMarDirector *dir) {
 		case 7192002:			
             if (!codeContainer.isCodeActive(SUN_DRIP))
                 codeContainer.forceActivateCode(SUN_DRIP);
+            break;
         case 69420:
             codeContainer.rollTime = 0.5;
+            break;
         case 11211990:
             if (!codeContainer.isCodeActive(SPAWN_YOSHI))
                 codeContainer.forceActivateCode(SPAWN_YOSHI);
             if (codeContainer.isCodeActive(MOVE_OR_DIE))
                 codeContainer.endCode(MOVE_OR_DIE);
+            break;
 	};
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -407,7 +407,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
         {CLUMSY_JUMPS,              "Clumsy Jumps",                     60,			20,		    codeContainer.lockJumpDirection},
         {PATHETIC_FLUDD,            "Pathetic FLUDD",                   70,			30,		    codeContainer.sadFLUDD},
         {LAND_MOVEMENT_LOCK,        "Landing Movement Lock",            40,			30,		    codeContainer.landMovementLock},
-        {UNLIMITED_TURBO,           "Unlimited Turbo but no Turbo",     25,			30,		    codeContainer.forceTurbo},
+        {UNLIMITED_TURBO,           "Unlimited Turbo but no Turbo",     25,			25,		    codeContainer.forceTurbo},
         {CRESCENDO,                 "Crescendo",                        50,         30,         codeContainer.setMusicVol},
         {SPEEN_ID,                  "S P E E N",                        45,         10,         codeContainer.SPEEN},
         {NOZZLE_ROLL,               "Nozzle Roulette",			        40,          7,         codeContainer.changeNozzleRandom},
@@ -486,7 +486,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
         {MOVE_OR_DIE,				"Move or... DIE!!!",				25,			30,			codeContainer.moveOrDie},
         {DIVING_MODE,				"CAMERA BAD",						50,			30,			codeContainer.divingMode},
         {PAUSE_TIMERS,				"Pause Codes",						20,			30,			codeContainer.pauseTimers},	
-        {CHANGE_MUSIC,				"Change Music",						30,			 1,			codeContainer.changeMusic},
+        {CHANGE_MUSIC,				"Change Music",						35,			 1,			codeContainer.changeMusic},
         {OFFSET_MARIO,				"Offset Mario",						50,			30,			codeContainer.offsetMarioToggle},
         {REVERSE_MARIO,				"Reverse Mario",					50,			30,			codeContainer.reverseMarioToggle},
         {FAKE_DEATH,				"Kill Mario",						25,			 5,			codeContainer.fakeDeath},
@@ -505,7 +505,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
     #if DEV_MODE
 
     // any code names listed here will get their rarity set to 100 while the rest are set to 0
-    u8 whitelist[] = {NO_WHITELIST	};
+    u8 whitelist[] = {NO_WHITELIST};
     if (!(whitelist[0] == NO_WHITELIST)) {
         for (Code c : addList) {
             for (u8 id : whitelist) {
@@ -750,7 +750,7 @@ BETTER_SMS_FOR_CALLBACK static void setSeedCallback(TApplication *tapp) {
     };
 
     static int stickHoldStarted = 0;		// the value of sCustomRNGSeed when it began to get changed
-    static int step				= 1;		// settings step amount
+    static int step				= 1;		// settings step amount/decimal place being stepped
     static bool holdingStick    = false;	// if holding stick > 0.3 on x axis
     static scrollStates scrollState = NOT_SCROLLING;
     f32 menuTime;
@@ -800,7 +800,22 @@ static void assignOnDeathDestination(JDrama::TFlagT<u16> nextStageFlag, u16 flag
 }
 SMS_PATCH_BL(SMS_PORT_REGION(0x80299808, 0, 0, 0), assignOnDeathDestination);	// credit both JoshuaMK (myself), CyrusLoS, and Eclipse Team as a whole. Any and all use of the source assets should credit Eclipse Team.
 
+BETTER_SMS_FOR_CALLBACK static void customSeeds(TMarDirector *dir) {
 
+	switch (sCustomRNGSeed) {
+		case 7192002:			
+            if (!codeContainer.isCodeActive(SUN_DRIP))
+                codeContainer.forceActivateCode(SUN_DRIP);
+        case 69420:
+            codeContainer.rollTime = 0.5;
+        case 11211990:
+            if (!codeContainer.isCodeActive(SPAWN_YOSHI))
+                codeContainer.forceActivateCode(SPAWN_YOSHI);
+            if (codeContainer.isCodeActive(MOVE_OR_DIE))
+                codeContainer.endCode(MOVE_OR_DIE);
+	};
+
+}
 
 // Module definition
 
@@ -816,6 +831,7 @@ static void initModule() {
     BetterSMS::Stage::addExitCallback(resetCodesOnStageExit);
     BetterSMS::Stage::addInitCallback(applyChaosSettings);
     BetterSMS::Stage::addUpdateCallback(titleScreenEngine);
+    BetterSMS::Stage::addUpdateCallback(customSeeds);
 
 	BetterSMS::Game::addLoopCallback(setSeedCallback);  
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -447,7 +447,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
         {MAKE_MARIO_OBJ,			"Prop Hunt",						65,			60,			codeContainer.makeMarioAnObject},
 		{POPUP_SAVE_PROMPT,			"Quicksave",						55,			 1,			codeContainer.popupSavePrompt},
 		{PING_LAG,					"Nintendo Online",					25,			25,			codeContainer.pingLag},
-		{HALVE_ROLL_TIME,			"No Grace Period",					15,			25,			codeContainer.halveRollTime},
+		{HALVE_ROLL_TIME,			"Halve Roll Time",					15,			25,			codeContainer.halveRollTime},
 		{EARTHQUAKE,				"Earthquake!!!!",					15,			25,			codeContainer.earthquake},
 		{SOMETIMES_DOUBLE_COINS,	"Double Coins???",					60,			30,			codeContainer.sometimesDoubleCoins},
 		{REVERSE_RARITIES,			"Rarity Swap",						 1,			90,			codeContainer.reverseRarities},
@@ -496,6 +496,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
         // idea: a code which draws the collision triangles in a radius (the matrix)
         // idea: bouncy surface code (make npcs or something bouncy to the touch)
 		// idea: a code that sets the camera to focus on the nearest object to mario
+
 	};
 
     #if DEV_MODE
@@ -524,6 +525,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
 
     //OSReport("Finished initVars!\n");
     Utils::printChaosPtrAddr();
+    Utils::srand();
     //OSReport("starPower addr: 0x%x\n", &codeContainer.starPower);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -399,7 +399,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
         {NO_MARIO_REDRAW,           "No Mario Redraw",		            60,			15,		    codeContainer.noMarioRedraw},									
         {HOLD_CAP,                  "Cappy?",                           75,			45,		    codeContainer.holdCapToggle},
         {NO_MACTOR_MODELS,          "The Void Calls...",		        20,			20,		    codeContainer.noMActorModels},
-        {STOP_TLIVEACTOR_PERFORM,   "Untitled",                         20,         20,         codeContainer.stopTLiveActorPerform},
+        {STOP_TLIVEACTOR_PERFORM,   "Untitled",                         15,         20,         codeContainer.stopTLiveActorPerform},
         {STOP_CONTROL_INPUTS,       ":)",                               20,			 1,		    codeContainer.stopControlInputs},
         {SPAM_SPRAY_CENTRAL,        "Spam Spray Central",               65,			20,		    codeContainer.spamSprayCentral},
         {ROLL_EXTRA_CODE,           "Roll Extra Code",                  20,			 5,		    codeContainer.rollExtraCode},
@@ -472,7 +472,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
         {SHRINK_RAY,				"Shrink Ray!",						40,			45,			codeContainer.shrinkRay},
         {CS_PLAYERS,				"CS Players",						50,			41.2,		codeContainer.csPlayers},
         {INVERT_MARIO,				"Inversion",						50,			45,		    codeContainer.invertMario},
-        {FIRE_MOVEMENT,				"MAMA!!",						    50,			30,		    codeContainer.fireMovement},
+        {FIRE_MOVEMENT,				"MAMA!!",						    50,			25,		    codeContainer.fireMovement},
         {LOL,						"lol",								40,			20,		    codeContainer.lol},
         {TILTED,					"Tilted",							65,			30,		    codeContainer.tilted},
         {POPUP_UX,				    "Popups",						    50,			 1,		    codeContainer.popUpUX},
@@ -481,10 +481,10 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
         {SIGHTSEER,					"Delfino Sightseer",                10,			 1,			codeContainer.sightseer},
         {STAR_POWER,				"Star Power",						40,			10,			codeContainer.starPowerToggle},
         {TRIPPY_TEXTURES,			"Trippy",							50,			40,			codeContainer.trippyTextures},
-        {IMA_TIRED,					"I'ma Tired!",						50,			 1.5,		codeContainer.imaTired},
+        {IMA_TIRED,					"I'ma Tired!",						50,			1.5,		codeContainer.imaTired},
         {FREEZE_ANIMS,				"Stop Motion",						60,			30,			codeContainer.freezeAnims},
         {MOVE_OR_DIE,				"Move or... DIE!!!",				25,			30,			codeContainer.moveOrDie},
-        {DIVING_MODE,				"CAMERA BAD",						50,			30,			codeContainer.divingMode},
+        {DIVING_MODE,				"Scuba Mode",						50,			30,			codeContainer.divingMode},
         {PAUSE_TIMERS,				"Pause Codes",						20,			30,			codeContainer.pauseTimers},	
         {CHANGE_MUSIC,				"Change Music",						35,			 1,			codeContainer.changeMusic},
         {OFFSET_MARIO,				"Offset Mario",						50,			30,			codeContainer.offsetMarioToggle},
@@ -505,7 +505,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
     #if DEV_MODE
 
     // any code names listed here will get their rarity set to 100 while the rest are set to 0
-    u8 whitelist[] = {NO_WHITELIST};
+    u8 whitelist[] = {FIRE_MOVEMENT, MOVE_OR_DIE};
     if (!(whitelist[0] == NO_WHITELIST)) {
         for (Code c : addList) {
             for (u8 id : whitelist) {
@@ -711,6 +711,8 @@ BETTER_SMS_FOR_CALLBACK static void titleScreenEngine(TMarDirector *director) {
 
 	skippableCutscenesPatch1.set_enabled(sSkipCutscenes);
 	skippableCutscenesPatch2.set_enabled(sSkipCutscenes);	
+
+	codeContainer.disableStopTLiveActorPerform();	// not a title screen thing but im too lazy to make another game update callback
 
 	if (director->mAreaID != 15)
         return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -791,6 +791,16 @@ BETTER_SMS_FOR_CALLBACK static void customSeeds(TMarDirector *dir) {
             if (codeContainer.isCodeActive(MOVE_OR_DIE))
                 codeContainer.endCode(MOVE_OR_DIE);
             break;
+        case 882000:
+            if (!codeContainer.isCodeActive(PAINT_RANDOM_COLLISION))
+                codeContainer.forceActivateCode(PAINT_RANDOM_COLLISION);
+            if (!codeContainer.isCodeActive(SPAM_SPRAY_CENTRAL))
+                codeContainer.forceActivateCode(SPAM_SPRAY_CENTRAL);
+        case 12202003:
+            if (!codeContainer.isCodeActive(OUT_OF_BODY))
+                codeContainer.forceActivateCode(OUT_OF_BODY);
+            if (!codeContainer.isCodeActive(MOVE_SHINES))
+                codeContainer.forceActivateCode(MOVE_SHINES);
 	};
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -491,7 +491,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
         {REVERSE_MARIO,				"Reverse Mario",					50,			30,			codeContainer.reverseMarioToggle},
         {FAKE_DEATH,				"Kill Mario",						25,			 5,			codeContainer.fakeDeath},
         {TINY_MARIO,				"Tiny Mario",						50,			30,			codeContainer.tinyMario},
-        {SELFIE_STICK,				"Selfie Stick",						20,			30,			codeContainer.selfieStick},
+        {SELFIE_STICK,				"Selfie Stick",						20,			15,			codeContainer.selfieStick},
         {RAINBOW_WATER,				"Rainbow Water!",					50,			30,			codeContainer.rainbowWater},
         {OUT_OF_BODY,				"Lucid Dream",					    40,			30,			codeContainer.outOfBody}
         // idea: code that adds companion (maybe companion can pick you up and throw you)
@@ -745,6 +745,29 @@ BETTER_SMS_FOR_CALLBACK static void setSeedCallback(TApplication *tapp) {
 	if (tapp->mCurrentScene.mAreaID != 15)	// has potential for conflicts with other mods
         return;
 
+	static bool zPressed	= false;
+    static bool lastZState	= false;
+    static int step			= 1;
+
+
+	if (tapp->mGamePads[0]->mButtons.mInput & JUTGamePad::EButtons::Z)
+        zPressed = true;
+    else
+        zPressed = false;
+    
+
+	if (zPressed && !lastZState)
+        step *= 10;
+    if (step > 1000000000)
+        step = 1;
+
+	lastZState = zPressed;
+
+	sCustomRNGSeedSetting.setValueRange({-0x7fffffff, 0x7fffffff, step});
+
+	return;
+
+
 	enum scrollStates {
         NOT_SCROLLING        = 0,
         SCROLLING			 = 1,
@@ -752,7 +775,7 @@ BETTER_SMS_FOR_CALLBACK static void setSeedCallback(TApplication *tapp) {
     };
 
     static int stickHoldStarted = 0;		// the value of sCustomRNGSeed when it began to get changed
-    static int step				= 1;		// settings step amount/decimal place being stepped
+    //static int step				= 1;		// settings step amount/decimal place being stepped
     static bool holdingStick    = false;	// if holding stick > 0.3 on x axis
     static scrollStates scrollState = NOT_SCROLLING;
     f32 menuTime;
@@ -877,7 +900,7 @@ static void initModule() {
 }
 
 // Definition block
-KURIBO_MODULE_BEGIN("Hyper Chaos", "Angry_Max, MasterMattK", "v1.0") {
+KURIBO_MODULE_BEGIN("Hyper Chaos", "Angry_Max, MasterMattK", "v1.1") {
     // Set the load and unload callbacks to our registration functions
     KURIBO_EXECUTE_ON_LOAD { initModule(); }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -505,7 +505,7 @@ BETTER_SMS_FOR_CALLBACK static void initVars(TApplication *tapp) {
     #if DEV_MODE
 
     // any code names listed here will get their rarity set to 100 while the rest are set to 0
-    u8 whitelist[] = {FIRE_MOVEMENT, MOVE_OR_DIE};
+    u8 whitelist[] = {NO_WHITELIST};
     if (!(whitelist[0] == NO_WHITELIST)) {
         for (Code c : addList) {
             for (u8 id : whitelist) {

--- a/src/p_main.hxx
+++ b/src/p_main.hxx
@@ -23,7 +23,7 @@
 
 #include "codes.hxx"
 
-#define DEV_MODE false
+#define DEV_MODE true
 
 // color definitions have been moved to codes.hxx :)
 

--- a/src/p_main.hxx
+++ b/src/p_main.hxx
@@ -23,7 +23,7 @@
 
 #include "codes.hxx"
 
-#define DEV_MODE true
+#define DEV_MODE false
 
 // color definitions have been moved to codes.hxx :)
 


### PR DESCRIPTION
## **Patchnotes:**

### RNG Seeds
A new setting to set a seed has been added! The seed only affects the order of codes that you get, and nothing else. Here are some notes:

- The seeded RNG starts once you leave title screen.
- If the seed is left at 0, it'll just be a random seed.
- Pressing Z while setting the seed changes the decimal place that you're changing.

### Code Changes, Tweaks, and Bug Fixes

- "Dummy Thicc Mario" no longer can activate on title screen due to messing up the settings menu.
- "Unlimited Turbo but no Turbo" has been adjusted to last only 25 seconds, instead of the previous 30 to avoid bonk-locks(wordplay).
- "Change Music" has become slightly more common.
- "CAMERA BAD" has been renamed to "Scuba Mode."
- Fixed a crash that happened when the player got swallowed by the Eel after having "CAMERA BAD"/"Scuba Mode" deactivate shortly before. This means that "Scuba Mode" will no longer put the player into the non-diving state while fighting Eel.
- Shortened "MAMA!!" from 30 seconds to 25.
- "Untitled" will now disable if Mario dies while its active in order to avoid death loops.
- "Untitled" now pops in and out, just like "Double Perspective."
- Fixed a crash that occurred when "Sun Drip" activated while "No Mario Redraw" was active by making them partially exclusive. This means that "Sun Drip" cannot activate while "No Mario Redraw" is active, however, the reverse can still happen!
- "Selfie Stick" has been drastically nerfed from lasting 30 seconds down to only 15 seconds.

### New Mutually Exclusive Codes
Some codes do not work very well or at all together. Since 1.0 was released, we've discovered some codes that weren't mutually exclusive, but now are. Those codes would be:

- "Tiny Mario" & "Inversion"
- "Prop Hunt" & "Lucid Dream"
- "Double Time!!" and "Pause Codes"